### PR TITLE
fix(contact): update form redirect URL to external thank-you page

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -138,7 +138,7 @@
                   <input
                     type="hidden"
                     name="_next"
-                    value="../thank-you/index.html"
+                    value="https://pichuelectrico.github.io/MetrumDesign/thanks/"
                   />
                   <!-- Campo oculto para personalizar el asunto del email -->
                   <input


### PR DESCRIPTION
Change the _next hidden input value to point to the external thank-you page URL. This ensures users are redirected correctly after form submission, improving user experience and handling deployment on GitHub Pages.