### PR TITLE
fix(contact): disable hidden captcha input in contact form

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -133,7 +133,7 @@
                   data-fail-msg="Sorry it seems that our mail server is not responding, Sorry for the inconvenience!"
                 >
                   <!-- Campo oculto para desactivar captcha -->
-                  <input type="hidden" name="_captcha" value="false" />
+                  <!-- <input type="hidden" name="_captcha" value="false" /> -->
                   <!-- Campo oculto para redirección después del envío -->
                   <input
                     type="hidden"


### PR DESCRIPTION
Comment out the hidden input that disables captcha to ensure the
captcha validation is active. This change improves form security by
preventing spam submissions through the contact page.